### PR TITLE
fix: remove broken link to WAR file guide 404

### DIFF
--- a/build_an_executable_jar_with_both.adoc
+++ b/build_an_executable_jar_with_both.adoc
@@ -20,4 +20,4 @@ java -jar target/{project_id}-0.1.0.jar
 ----
 ====
 
-NOTE: The steps described here create a runnable JAR. You can also link:/guides/gs/convert-jar-to-war/[build a classic WAR file].
+


### PR DESCRIPTION
This fix removes a broken link to the "build a classic WAR file" guide, which returns a 404 error. The outdated reference has been deleted from the documentation to improve the user experience and avoid confusion for contributors and readers.

This fix addresses the issue by removing the outdated reference to the WAR file guide

![image](https://github.com/user-attachments/assets/fe80dbb4-4fa2-43cd-a131-efaf698cac26)

![image](https://github.com/user-attachments/assets/fe1188da-b458-48f2-af46-18df713d9cd2)

Github repo referenced to it
![image](https://github.com/user-attachments/assets/df7a6ff9-741b-4674-8980-c5822a782f23)
